### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/ai/server.js
+++ b/ai/server.js
@@ -96,7 +96,16 @@ async function Server() {
       const { provider, baseurl } = req.query;
       if (provider === "ollama") {
         try {
-          const results = await fetch(baseurl ? `${baseurl}/api/tags` : `http://localhost:11434/api/tags`);
+          // Define an allow-list of trusted base URLs
+          const allowedBaseUrls = ['http://localhost:11434', 'https://trusted.example.com'];
+          
+          // Validate the baseurl against the allow-list
+          const validatedBaseUrl = allowedBaseUrls.includes(baseurl) ? baseurl : null;
+          if (!validatedBaseUrl) {
+            return res.status(400).json({ error: 'Invalid baseurl provided' });
+          }
+          
+          const results = await fetch(`${validatedBaseUrl}/api/tags`);
           if (!results.ok) {
             return res.status(404).json({ error: 'Failed to fetch models from Ollama' });
           }


### PR DESCRIPTION
Potential fix for [https://github.com/abharatu/agenticai/security/code-scanning/1](https://github.com/abharatu/agenticai/security/code-scanning/1)

To fix the issue, we need to validate and restrict the `baseurl` parameter to ensure it cannot be used to construct malicious URLs. The best approach is to use an allow-list of trusted base URLs and reject any user input that does not match the allow-list. This ensures that only predefined, safe URLs can be used in the `fetch` call.

Steps to implement the fix:
1. Define an allow-list of trusted base URLs.
2. Check if the `baseurl` parameter matches one of the trusted URLs in the allow-list.
3. If `baseurl` is not in the allow-list, reject the request with an appropriate error message.
4. Use the validated `baseurl` to construct the URL for the `fetch` call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
