### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/ai/package.json
+++ b/ai/package.json
@@ -16,7 +16,8 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "pdf-parse": "^1.1.1",
-    "wikipedia": "^2.1.2"
+    "wikipedia": "^2.1.2",
+    "express-rate-limit": "^7.5.1"
   },
   "author": "Vikrama Aditya Bharatula",
   "license": "ISC",

--- a/ai/server.js
+++ b/ai/server.js
@@ -25,6 +25,14 @@ async function Server() {
     app.use(cors());
     app.use(express.json());
 
+    // Set up rate limiter: maximum of 100 requests per 15 minutes
+    const RateLimit = (await import('express-rate-limit')).default;
+    const limiter = RateLimit({
+      windowMs: 15 * 60 * 1000, // 15 minutes
+      max: 100, // limit each IP to 100 requests per windowMs
+      message: { error: "Too many requests, please try again later." }
+    });
+
     // =========================
     // Health Check Endpoint
     // =========================
@@ -346,7 +354,7 @@ async function Server() {
      *       500:
      *         description: Failed to read MCP.json
      */
-    app.get('/api/mcpconfig', async (req, res) => {
+    app.get('/api/mcpconfig', limiter, async (req, res) => {
       try {
         const fs = await import('fs/promises');
         const path = await import('path');


### PR DESCRIPTION
Potential fix for [https://github.com/abharatu/agenticai/security/code-scanning/2](https://github.com/abharatu/agenticai/security/code-scanning/2)

To address the issue, we will introduce rate limiting to the `/api/mcpconfig` endpoint using the `express-rate-limit` package. This package allows us to define a maximum number of requests that can be made to the endpoint within a specified time window. Specifically:
1. Install the `express-rate-limit` package if it is not already installed.
2. Configure a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
3. Apply the rate limiter middleware to the `/api/mcpconfig` route.

This fix ensures that the endpoint is protected against abuse while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
